### PR TITLE
Add `quality_check` parameter to Release workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -10,6 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     uses: gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main
     with:
+      quality_check: ""
       inject_mupdate: false
     secrets: inherit
     permissions:


### PR DESCRIPTION
Disables the quality check step in the release workflow by passing an empty string for the `quality_check` input.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `quality_check: ""` input to the `ReleaseMudlet.yaml` reusable workflow call in `Release.yaml`, intentionally disabling the quality check step during releases.

- The workflow correctly targets `@main` on the reusable workflow reference, satisfying the project's branching convention.
- Passing an empty string for `quality_check` is the intended mechanism to skip that step in the upstream `ReleaseMudlet.yaml` workflow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line addition that disables the quality check step in the release workflow as described.

The change is minimal and intentional: it adds one input to an existing reusable workflow call to disable quality checks. The @main branch target is correctly preserved, and there are no logic or configuration issues introduced.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["forgot to turn off waiting for quality"](https://github.com/gesslar/oxidusui/commit/f5aae0d793155d2e7bd91a9606f7a04f6d8bf12e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31836710)</sub>

<!-- /greptile_comment -->