### PR TITLE
Add version bump scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "build": "npx @gesslar/muddy",
     "watch": "npx @gesslar/muddy -w",
+    "major": "npx @gesslar/muddy version major",
+    "minor": "npx @gesslar/muddy version minor",
+    "patch": "npx @gesslar/muddy version patch",
     "pr": "gt submit -p --ai"
   },
   "license": "0BSD"


### PR DESCRIPTION
Adds `major`, `minor`, and `patch` npm scripts to streamline version bumping using the `muddy` CLI, allowing version updates to be triggered directly via `npm run major`, `npm run minor`, or `npm run patch`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `major`, `minor`, and `patch` npm scripts to `package.json` for streamlined version bumping via the `@gesslar/muddy` CLI, matching the same invocation style as the existing `build` and `watch` scripts.

- Three new scripts delegate to `npx @gesslar/muddy version <level>`, enabling `npm run major|minor|patch` as version bump shortcuts.

<h3>Confidence Score: 5/5</h3>

Minimal, additive-only change to package.json scripts with no impact on existing functionality.

The change adds three npm convenience scripts that follow the same pattern as the existing build/watch scripts. No logic, dependencies, or configuration is modified.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["adding new scripts"](https://github.com/gesslar/oxidusui/commit/ff69ab40ee68b743a1d93a100a7f83888caefed8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31905897)</sub>

<!-- /greptile_comment -->